### PR TITLE
DON'T MERGE Simplified the decryption process for the shared cookie

### DIFF
--- a/spa-design/lib/sso_session.rb
+++ b/spa-design/lib/sso_session.rb
@@ -11,19 +11,17 @@ module SharedSession
 
   # https://github.com/rails/rails/blob/4-2-stable/activesupport/lib/active_support/message_encryptor.rb#L90
   def decrypt(request)
-    config = Rails.application.secrets['rdls_sessions']
-    key = config[:shared_secret]
-    cookie = request.cookies[config[:name]]
-
-    secret = OpenSSL::PKCS5.pbkdf2_hmac_sha1(key, 'encrypted cookie', 1000, 64)
+    config = Rails.application.secrets.sso
+    secret = config['shared_secret'][0, 32]
+    cookie = request.cookies[config['cookie']['name']]
 
     encrypted_message = Base64.decode64(cookie)
-    cipher = OpenSSL::Cipher.new('aes-256-cbc')
+    cipher = OpenSSL::Cipher.new('aes-256-gcm')
 
     encrypted_data, iv = encrypted_message.split("--").map {|v| ::Base64.decode64(v)}
 
     cipher.decrypt
-    cipher.key = secret[0, 32]
+    cipher.key = secret
     cipher.iv  = iv
 
     decrypted_data = cipher.update(encrypted_data)

--- a/sso-prototype/django-api/accounts/views.py
+++ b/sso-prototype/django-api/accounts/views.py
@@ -11,13 +11,13 @@ unpad = lambda s: s[:-ord(s[len(s) - 1:])]
 
 
 class OXSessionDecryptor(object):
-    def __init__(self, secret_key_base, salt="encrypted cookie", keylen=64, iterations=1000):
-        self.secret = PBKDF2(secret_key_base, salt.encode(), keylen, iterations)
+    def __init__(self, shared_secret):
+        self.secret = shared_secret[:32]
 
     def get_cookie_data(self, cookie):
         cookie = base64.b64decode(urllib.parse.unquote(cookie).split('--')[0])
         encrypted_data, iv = map(base64.b64decode, cookie.split('--'.encode()))
-        cipher = AES.new(self.secret[:32], AES.MODE_CBC, iv)
+        cipher = AES.new(self.secret, AES.MODE_GCM, iv)
         return json.loads(unpad(cipher.decrypt(encrypted_data)))
 
 
@@ -26,6 +26,6 @@ def auth(request):
     if not cookie:
         return JsonResponse({ 'logged_in': False })
 
-    decrypt = OXSessionDecryptor(secret_key_base=settings.SHARED_SECRET)
+    decrypt = OXSessionDecryptor(shared_secret=settings.SHARED_SECRET)
     decrypted_user = decrypt.get_cookie_data(cookie)
     return JsonResponse(decrypted_user)

--- a/sso-prototype/django-api/accounts/views.py
+++ b/sso-prototype/django-api/accounts/views.py
@@ -17,7 +17,7 @@ class OXSessionDecryptor(object):
     def get_cookie_data(self, cookie):
         cookie = base64.b64decode(urllib.parse.unquote(cookie).split('--')[0])
         encrypted_data, iv = map(base64.b64decode, cookie.split('--'.encode()))
-        cipher = AES.new(self.secret, AES.MODE_GCM, iv)
+        cipher = AES.new(self.secret, AES.MODE_CBC, iv)
         return json.loads(unpad(cipher.decrypt(encrypted_data)))
 
 

--- a/sso-prototype/homepage/lib/shared_session.rb
+++ b/sso-prototype/homepage/lib/shared_session.rb
@@ -16,7 +16,7 @@ module SharedSession
     cookie = request.cookies[config['cookie']['name']]
 
     encrypted_message = Base64.decode64(cookie)
-    cipher = OpenSSL::Cipher.new('aes-256-gcm')
+    cipher = OpenSSL::Cipher.new('aes-256-cbc')
 
     encrypted_data, iv = encrypted_message.split("--").map {|v| ::Base64.decode64(v)}
 

--- a/sso-prototype/homepage/lib/shared_session.rb
+++ b/sso-prototype/homepage/lib/shared_session.rb
@@ -11,19 +11,17 @@ module SharedSession
 
   # https://github.com/rails/rails/blob/4-2-stable/activesupport/lib/active_support/message_encryptor.rb#L90
   def decrypt(request)
-    config = Rails.application.secrets['rdls_sessions']
-    key = config[:shared_secret]
-    cookie = request.cookies[config[:name]]
-
-    secret = OpenSSL::PKCS5.pbkdf2_hmac_sha1(key, 'encrypted cookie', 1000, 64)
+    config = Rails.application.secrets.sso
+    secret = config['shared_secret'][0, 32]
+    cookie = request.cookies[config['cookie']['name']]
 
     encrypted_message = Base64.decode64(cookie)
-    cipher = OpenSSL::Cipher.new('aes-256-cbc')
+    cipher = OpenSSL::Cipher.new('aes-256-gcm')
 
     encrypted_data, iv = encrypted_message.split("--").map {|v| ::Base64.decode64(v)}
 
     cipher.decrypt
-    cipher.key = secret[0, 32]
+    cipher.key = secret
     cipher.iv  = iv
 
     decrypted_data = cipher.update(encrypted_data)

--- a/sso-prototype/rails-api/lib/shared_session.rb
+++ b/sso-prototype/rails-api/lib/shared_session.rb
@@ -16,7 +16,7 @@ module SharedSession
     cookie = request.cookies[config['cookie']['name']]
 
     encrypted_message = Base64.decode64(cookie)
-    cipher = OpenSSL::Cipher.new('aes-256-gcm')
+    cipher = OpenSSL::Cipher.new('aes-256-cbc')
 
     encrypted_data, iv = encrypted_message.split("--").map {|v| ::Base64.decode64(v)}
 

--- a/sso-prototype/rails-api/lib/shared_session.rb
+++ b/sso-prototype/rails-api/lib/shared_session.rb
@@ -11,19 +11,17 @@ module SharedSession
 
   # https://github.com/rails/rails/blob/4-2-stable/activesupport/lib/active_support/message_encryptor.rb#L90
   def decrypt(request)
-    config = Rails.application.secrets['rdls_sessions']
-    key = config[:shared_secret]
-    cookie = request.cookies[config[:name]]
-
-    secret = OpenSSL::PKCS5.pbkdf2_hmac_sha1(key, 'encrypted cookie', 1000, 64)
+    config = Rails.application.secrets.sso
+    secret = config['shared_secret'][0, 32]
+    cookie = request.cookies[config['cookie']['name']]
 
     encrypted_message = Base64.decode64(cookie)
-    cipher = OpenSSL::Cipher.new('aes-256-cbc')
+    cipher = OpenSSL::Cipher.new('aes-256-gcm')
 
     encrypted_data, iv = encrypted_message.split("--").map {|v| ::Base64.decode64(v)}
 
     cipher.decrypt
-    cipher.key = secret[0, 32]
+    cipher.key = secret
     cipher.iv  = iv
 
     decrypted_data = cipher.update(encrypted_data)


### PR DESCRIPTION
Removed the key derivation step, which is no longer needed because we are now using a separate shared secret for this cookie.

You might want to delay merging because I don't have plans to deploy the updated cookie to rdls.org